### PR TITLE
Make InputMap Generic

### DIFF
--- a/examples/hello_world_enum.rs
+++ b/examples/hello_world_enum.rs
@@ -1,0 +1,43 @@
+use bevy::prelude::*;
+use bevy_input_actionmap::*;
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ActionPlugin::<Action>::default())
+        .add_startup_system(setup.system())
+        .add_system(run_commands.system())
+        .run();
+}
+
+#[derive(Hash, PartialEq, Eq, Clone)]
+enum Action {
+    Select,
+    SuperSelect,
+    AwesomeSuperSelect,
+}
+
+fn setup(mut input: ResMut<InputMap<Action>>) {
+    input
+        .bind(Action::Select, KeyCode::Return)
+        .bind(Action::Select, GamepadButtonType::South)
+        .bind(Action::SuperSelect, vec![KeyCode::LAlt, KeyCode::Return])
+        .bind(Action::SuperSelect, vec![KeyCode::RAlt, KeyCode::Return])
+        // This should bind left/right control and left/right alt, but the combos would get ridiculous so hopefully this is sufficient.
+        .bind(
+            Action::AwesomeSuperSelect,
+            vec![KeyCode::LAlt, KeyCode::LControl, KeyCode::Return],
+        );
+}
+
+fn run_commands(input: Res<InputMap<Action>>) {
+    if input.just_active(Action::Select) {
+        println!("Selected");
+    }
+    if input.just_active(Action::SuperSelect) {
+        println!("Super selected");
+    }
+    if input.just_active(Action::AwesomeSuperSelect) {
+        println!("Awesome super selected");
+    }
+}

--- a/examples/hello_world_string.rs
+++ b/examples/hello_world_string.rs
@@ -4,7 +4,7 @@ use bevy_input_actionmap::*;
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
-        .add_plugin(ActionPlugin)
+        .add_plugin(ActionPlugin::<String>::default())
         .add_startup_system(setup.system())
         .add_system(run_commands.system())
         .run();
@@ -14,7 +14,7 @@ const ACTION_SELECT: &str = "SELECT";
 const ACTION_SUPER_SELECT: &str = "SUPER_SELECT";
 const ACTION_AWESOME_SUPER_SELECT: &str = "AWESOME_SUPER_SELECT";
 
-fn setup(mut input: ResMut<InputMap>) {
+fn setup(mut input: ResMut<InputMap<String>>) {
     input
         .bind(ACTION_SELECT, KeyCode::Return)
         .bind(ACTION_SELECT, GamepadButtonType::South)
@@ -27,7 +27,7 @@ fn setup(mut input: ResMut<InputMap>) {
         );
 }
 
-fn run_commands(input: Res<InputMap>) {
+fn run_commands(input: Res<InputMap<String>>) {
     if input.just_active(ACTION_SELECT) {
         println!("Selected");
     }


### PR DESCRIPTION
This PR does the bare minimum required to make the `InputMap` type generic. In order to take advantage of compile-time assurances, this change would allow users to create `InputMap`s over whichever type they choose, but my main goal was to allow the use of `enum`s alongside `String`s.

I'm sure there is some clean up that could be done.

One thing to note is that the key type used in `InputMap` must implement the following traits at minimum: `Hash + Eq + Clone + Send + Sync`. These were implicit before because `String` already implements them. Per a discussion on the discord channel, there may be a way to wrap this up nicely with an attribute proc_macro. I believe the type should also be able to be de/serialized by whatever means Bevy usually does that, but that was beyond the intent of this PR.