### PR TITLE
cut down default dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main" }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false }
+
+[dev-dependencies]
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_winit", "x11"] }


### PR DESCRIPTION
Now using this crate won't also pull dependencies for audio, gltf etc.