### PR TITLE
added basic serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ edition = "2018"
 
 [dependencies]
 bevy = { version = "0.5", default-features = false }
+ron = { version = "*", optional = true }
+serde = { version = "*", optional = true }
 
 [dev-dependencies]
 bevy = { version = "0.5", default-features = false, features = ["bevy_winit", "x11"] }
+
+[features]
+serialize = ["ron", "bevy/serialize", "serde"]

--- a/examples/hello_world_serde.rs
+++ b/examples/hello_world_serde.rs
@@ -1,0 +1,65 @@
+use bevy::prelude::*;
+use bevy_input_actionmap::*;
+fn main() {
+    App::build()
+    .add_plugins(DefaultPlugins)
+    .add_plugin(ActionPlugin::<Action>::default())
+    .add_startup_system(setup.system())
+    .add_system(run_commands.system())
+    .run();
+}
+
+#[derive(Hash, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+enum Action {
+    Select,
+    SuperSelect,
+    AwesomeSuperSelect,
+}
+
+#[cfg(feature = "serialize")]
+fn setup(mut input: ResMut<InputMap<Action>>) {
+    if let Err(_) = input.load_from_path("keybinds.config") {
+        {   println!("no keybind config found creating default setup"); //just to show the path it took
+            input
+            .bind(Action::Select, KeyCode::Return)
+            .bind(Action::Select, GamepadButtonType::South)
+            .bind(Action::SuperSelect, vec![KeyCode::LAlt, KeyCode::Return])
+            .bind(Action::SuperSelect, vec![KeyCode::RAlt, KeyCode::Return])
+            // This should bind left/right control and left/right alt, but the combos would get ridiculous so hopefully this is sufficient.
+            .bind(
+                Action::AwesomeSuperSelect,
+                vec![KeyCode::LAlt, KeyCode::LControl, KeyCode::Return],
+            );
+            input.save_to_path("keybinds.config").unwrap()}
+    } else {//if it loaded custom keybinds dont add new ones
+        println!("keybinds loaded from local file") //just to show the path it took
+    }
+    
+}
+#[cfg(not(feature = "serialize"))]
+fn setup(mut input: ResMut<InputMap<Action>>){
+    println!("serialize feature is off so this is the same as hello_world_enum; Why just Why");
+    input
+            .bind(Action::Select, KeyCode::Return)
+            .bind(Action::Select, GamepadButtonType::South)
+            .bind(Action::SuperSelect, vec![KeyCode::LAlt, KeyCode::Return])
+            .bind(Action::SuperSelect, vec![KeyCode::RAlt, KeyCode::Return])
+            // This should bind left/right control and left/right alt, but the combos would get ridiculous so hopefully this is sufficient.
+            .bind(
+                Action::AwesomeSuperSelect,
+                vec![KeyCode::LAlt, KeyCode::LControl, KeyCode::Return],
+            );
+}
+
+fn run_commands(input: Res<InputMap<Action>>) {
+    if input.just_active(Action::Select) {
+        println!("Selected");
+    }
+    if input.just_active(Action::SuperSelect) {
+        println!("Super selected");
+    }
+    if input.just_active(Action::AwesomeSuperSelect) {
+        println!("Awesome super selected");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,13 @@ use bevy::{
     prelude::*,
 };
 
+#[cfg(feature = "serialize")]
+pub mod serialize;
+#[cfg(feature = "serialize")]
+pub use serde::{Serialize, Deserialize};
+
 #[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Binding {
     keys: HashSet<KeyCode>,
     gamepad_buttons: HashSet<GamepadButtonType>,
@@ -66,6 +72,7 @@ impl From<Vec<GamepadButtonType>> for Binding {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum GamepadAxisDirection {
     LeftStickXPositive,
     LeftStickXNegative,
@@ -130,6 +137,7 @@ impl Binding {
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Action {
     bindings: Vec<Binding>,
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,0 +1,103 @@
+use super::*;
+use serde::{Serialize, de::DeserializeOwned};
+
+#[cfg(test)]
+mod test{
+    const ACTION_SELECT: &str = "SELECT";
+    const ACTION_SUPER_SELECT: &str = "SUPER_SELECT";
+    const ACTION_AWESOME_SUPER_SELECT: &str = "AWESOME_SUPER_SELECT";
+    const TESTPATH : &str = "test.keymap";
+    use bevy::prelude::*;
+    use super::*;
+    #[derive(Hash, PartialEq, Eq, Clone, Serialize, serde::Deserialize, Debug)]
+    enum TestAction {
+        Select,
+        SuperSelect,
+        AwesomeSuperSelect,
+    }
+    fn test_binding<T>(to_test : T) where T : Into<Binding>{
+        let binding : Binding = to_test.into();
+        let serialized = ron::to_string(&binding).expect("Failed to serialize binding");
+        let deserialized : Binding = ron::from_str(&serialized).expect("Failed to deserialize binding");
+        assert_eq!(binding, deserialized);
+    }
+    
+    
+    fn test_action(action : Action){
+        let serialized = ron::to_string(&action).expect("Failed to serialize action");
+        let deserialized : Action = ron::from_str(&serialized).expect("Failed to deserialize action");
+        assert_eq!(action, deserialized)
+    }
+    #[test]
+    fn test_inputmap_string(){
+        let mut map = super::InputMap::<String>::default();
+        map.bind(ACTION_SELECT, KeyCode::Return)
+        .bind(ACTION_SELECT, GamepadButtonType::South)
+        .bind(ACTION_SUPER_SELECT, vec![KeyCode::LAlt, KeyCode::Return])
+        .bind(ACTION_SUPER_SELECT, vec![KeyCode::RAlt, KeyCode::Return])
+        // This should bind left/right control and left/right alt, but the combos would get ridiculous so hopefully this is sufficient.
+        .bind(
+            ACTION_AWESOME_SUPER_SELECT,
+            vec![KeyCode::LAlt, KeyCode::LControl, KeyCode::Return],
+        );
+        map.save_to_path(TESTPATH).expect("Failed to save string InputMap");
+        let new_map = InputMap::<String>::new_from_path(TESTPATH).expect("Failed to load string InputMap");
+        assert_eq!(map.actions, new_map.actions);
+        map.load_from_path(TESTPATH).expect("Failed to Load from path");
+        assert_eq!(map.actions, new_map.actions);
+    }
+
+    fn test_inputmap_enum(){
+        let mut map = super::InputMap::<TestAction>::default();
+        map.bind(TestAction::Select, KeyCode::Return)
+        .bind(TestAction::Select, GamepadButtonType::South)
+        .bind(TestAction::SuperSelect, vec![KeyCode::LAlt, KeyCode::Return])
+        .bind(TestAction::SuperSelect, vec![KeyCode::RAlt, KeyCode::Return])
+        // This should bind left/right control and left/right alt, but the combos would get ridiculous so hopefully this is sufficient.
+        .bind(
+            TestAction::AwesomeSuperSelect,
+            vec![KeyCode::LAlt, KeyCode::LControl, KeyCode::Return],
+        );
+        map.save_to_path(TESTPATH).expect("Failed to save enum InputMap");
+        let new_map = InputMap::<TestAction>::new_from_path(TESTPATH).expect("Failed to load enum InputMap");
+        assert_eq!(map.actions, new_map.actions);
+        map.load_from_path(TESTPATH).expect("Failed to Load from path");
+        assert_eq!(map.actions, new_map.actions);
+    }
+    
+    #[test]
+    fn it_works(){
+        test_binding(KeyCode::Space);
+        test_binding(vec![KeyCode::Space, KeyCode::LControl]);
+        test_binding(GamepadButtonType::North);
+        test_binding(vec![GamepadButtonType::North, GamepadButtonType::LeftThumb]);
+        test_action(Action{
+            bindings : vec![KeyCode::Space.into(), KeyCode::J.into()]
+        });
+        test_inputmap_string();
+        test_inputmap_enum();
+        std::fs::remove_file(TESTPATH).expect("Failed to remove testsave file");
+    }
+}
+
+impl<T : Eq + Hash> InputMap<T> {
+    pub fn save_to_path(&self, path : &str) -> std::io::Result<()> where T : Serialize{
+        let contents = ron::ser::to_string_pretty(&self.actions, ron::ser::PrettyConfig::default()).expect("There was an error making the string");
+        std::fs::write(path, contents)
+    }
+    pub fn load_from_path(&mut self, path : &str) -> std::io::Result<()> where T : DeserializeOwned{
+        let ron_string = std::fs::read_to_string(path)?;
+        let actions = ron::from_str(&ron_string).expect("Failed to get actions from ron string");
+        self.actions = actions;
+        //may need to clear self here but i dont really know what that does
+        Ok(())
+    }
+    pub fn new_from_path(path : &str) -> std::io::Result<InputMap<T>> where T : DeserializeOwned{
+        let ron_string = std::fs::read_to_string(path)?;
+        let actions = ron::from_str(&ron_string).expect("Failed to get actions from ron string");
+        Ok(InputMap{
+            actions,
+            ..Default::default()
+        })
+    }
+}


### PR DESCRIPTION
added a feature to the create called "serialize" that adds the ability to save and load the actions  of an input map to a file. also made an example of how one might use said feature and a bunch of tests to make sure what is save and what is loaded is the same.

could maybe make it auto load files if the exist but this would need some thought about how to expose the save path to the developer.

could also add a version/merge system so that if an old keybind file is loaded new key binds will be added automatically; didn't do the auto merging here because it would mean working out a way to not override the custom keybinds and also not conflict with them