### PR TITLE
Relicense to MIT or Apache 2.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy_input_actionmap"
 version = "0.1.0"
 authors = ["Nolan Darilek <nolan@thewordnerd.info>"]
-license = "mit"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
I'd like to relicense this plugin to be compatible with Bevy.

I'm not going to be super formal about this. If all contributors agree by commenting on this issue, I'll merge this PR and relicense. If not, I'll rewrite the necessary code if the solution is not the obvious/only way to do a thing.

CC @rightfulerror @Silcet @jakobhellermann

Thanks!