### PR TITLE
Make axis strength always be positive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,7 +420,7 @@ where
                     };
                     if let Some((direction, opposite)) = direction {
                         if *strength != 0. {
-                            input.gamepad_axis.insert(direction, *strength);
+                            input.gamepad_axis.insert(direction, (*strength).abs());
                         } else {
                             input.gamepad_axis.remove(&direction);
                         }


### PR DESCRIPTION
Since an analog stick is split into four different inputs (i.e. negative x) it made more sense to me that the strength should always go from 0 to 1 regardless of which of the four directions it is.

How I use it in my own code:

```rust
pub trait AxisInput {
    fn horizontal(&self) -> f32;
}

impl AxisInput for InputMap<Action> {
    fn horizontal(&self) -> f32 {
        -self.strength(Action::Left) + self.strength(Action::Right)
    }
}

pub fn read_inputs(mut query: Query<&mut Player>, input_map: Res<InputMap<Action>>) {
    let horizontal = input_map.horizontal();
    // ...
}
```